### PR TITLE
feat: add get command for metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ your dot file progressively.
     - [Overriding dot entries](#overriding-dot-entries)
     - [Adding variables](#adding-variables)
     - [Adding hooks](#adding-hooks)
+    - [Helper scripts](#helper-scripts)
  - [Hooks](#hooks)
     - [Limitations](#limitations)
  - [Managing imports](#managing-imports)
@@ -396,7 +397,11 @@ hooks = [ "echo \"default profile\"" ]
 
 [profiles.corporate]
 hooks = [ "echo \"corporate profile\"" ]
-``` 
+```
+
+## Helper scripts
+
+If you use [Wofi](https://hg.sr.ht/~scoopta/wofi) as a menu/launcher, you can run the user script [`contrib/wofi-bombadil-switch-profile.sh`](https://github.com/oknozor/toml-bombadil/tree/main/contrib/wofi-bombadil-switch-profile.sh). Create a keyboard shortcut for this script to make switching Toml Bombadil profiles even more convenient. 
 
 
 ## Hooks

--- a/contrib/wofi-bombadil-switch-profile.sh
+++ b/contrib/wofi-bombadil-switch-profile.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+# Allow switching profiles using the wofi launcher/menu program (https://hg.sr.ht/~scoopta/wofi).
+
+if ! command -v bombadil &> /dev/null; then
+    echo "bombadil could not be found" >&2
+    exit 1
+fi
+
+if ! command -v wofi &> /dev/null; then
+    echo "wofi could not be found" >&2
+    exit 1
+fi
+
+SELECTED_PROFILE=$(bombadil get profiles | wofi -i -d -p "Switch Toml Bombadil Profile:")
+
+if [ "$SELECTED_PROFILE" = "default" ]; then
+    bombadil link
+else
+    bombadil link -p "$SELECTED_PROFILE"
+fi

--- a/tests/vars/bombadil.toml
+++ b/tests/vars/bombadil.toml
@@ -6,6 +6,6 @@ vars = ["vars.toml", "meta_vars.toml"]
 [settings.dots]
 dot_name = { source = "template.css", target = "template.css" }
 
-[settings.profiles.profile_name]
+[profiles.profile_name]
 vars = ["/tmp/var.toml"]
 hooks = ["echo hello world"]


### PR DESCRIPTION
The `get` command offers an interface into the metadata described in `bombadil.toml` configuration files. It can obtain information for:

- `dots`: name, target and source of each dot entry
- `hooks`: each hook command
- `path`: path of the current user's Toml Bombadil configuration
- `profiles`: each profile
- `vars`: name and value of each variable

This functionality was originally imagined for the purpose of offering an integration for the [Wofi](https://hg.sr.ht/~scoopta/wofi) menu/launcher. A script for that is added in the `contrib` folder.

This addresses part of #6. I don't use Rofi, so I didn't add a script for that.  This is a first-pass for the `get` command; I'm open to any other ideas about wording, command ergonomics, etc.