### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,10 @@ impl Bombadil {
 
     fn check_dotfile_dir(&self) -> Result<()> {
         if !self.path.exists() {
-            return Err(anyhow!("Dotfiles base path : {}, not found"));
+            return Err(anyhow!(
+                "Dotfiles base path : {}, not found",
+                self.path.display(),
+            ));
         }
 
         if !self.path.is_dir() {


### PR DESCRIPTION
Without this, the error message would literally be "Dotfiles base path : {}, not found" with curly braces in it instead of the path.