### PR TITLE
Remove DSpeckhals example repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Optionally you can display resources for a profile with the `--profiles` flag.
 If you use Bombadil please submit an issue, or a PR to update this section, we will be happy to reference your dotfiles here !
 
 - [https://github.com/oknozor/dotfiles](https://github.com/oknozor/dotfiles)
-- [https://github.com/DSpeckhals/dotfiles](https://github.com/DSpeckhals/dotfiles)
 - [https://github.com/mrkajetanp/dotfiles](https://github.com/mrkajetanp/dotfiles)
 - [https://github.com/HaoZeke/Dotfiles](https://github.com/HaoZeke/Dotfiles/tree/bombadil)
   


### PR DESCRIPTION
Since this commit https://github.com/DSpeckhals/dotfiles/commit/5f0710d6c850a704b6440a9057ed0e9a2c1bb6c4
The following _example repository_ https://github.com/DSpeckhals/dotfiles has moved away from toml-bombadil

Can be confusing for user to be redirect to some repo where missing bombadil.toml