### PR TITLE
chore: use 2018 module imports

### DIFF
--- a/src/dots.rs
+++ b/src/dots.rs
@@ -1,9 +1,10 @@
 use crate::gpg::Gpg;
 use crate::templating::Variables;
 use crate::unlink;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use colored::*;
 use dirs::home_dir;
+use serde_derive::{Deserialize, Serialize};
 use std::fs;
 use std::fs::File;
 use std::io::Write;

--- a/src/gpg.rs
+++ b/src/gpg.rs
@@ -1,5 +1,5 @@
 use crate::templating::Variables;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use colored::*;
+use serde_derive::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,10 @@
-#[macro_use]
-extern crate serde_derive;
-#[macro_use]
-extern crate anyhow;
-#[macro_use]
-extern crate pest_derive;
-
 use crate::dots::{Dot, DotVar};
 use crate::gpg::Gpg;
 use crate::hook::Hook;
 use crate::settings::{Profile, Settings};
 use crate::state::BombadilState;
 use crate::templating::Variables;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use colored::*;
 use std::collections::HashMap;
 use std::fs;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,8 +1,9 @@
 use crate::dots::{Dot, DotOverride};
 use crate::BOMBADIL_CONFIG;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use colored::Colorize;
 use config::{Config, ConfigError, File};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::Not;
 use std::path::PathBuf;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,8 +1,9 @@
 use crate::{unlink, Bombadil};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use colored::*;
 use config::Config;
 use config::File;
+use serde_derive::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::fs;
 use std::path::PathBuf;

--- a/src/templating.rs
+++ b/src/templating.rs
@@ -1,7 +1,8 @@
 use crate::gpg::{Gpg, GPG_PREFIX};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use colored::Colorize;
 use pest::Parser;
+use pest_derive::Parser;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;


### PR DESCRIPTION
This MR adjusts the module imports according to the changes in the 2018 edition:

https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html