### PR TITLE
Add codecov.yml and configure a threshold of 1%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+codecov:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
This is important when using codecov so we don't get silly failures like in #78.