### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ A dotfile manager.
 [dependencies]
 config = "0.13.1"
 dirs = "^4"
-toml = "^0"
+toml = "0.5"
 serde = { version = "1.0.139", features = ["derive"] }
 anyhow = "1.0.58"
 tera = "1.16.0"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.