### PR TITLE
Update profiles.md

### DIFF
--- a/website/docs/guide/profiles.md
+++ b/website/docs/guide/profiles.md
@@ -77,7 +77,7 @@ extra_profiles = [ "sway", "rofi", "solarized", "material-icons"]
 
 Now you can simply run:
 ```bash
-bombadil -p cool-sway
+bombadil link -p cool-sway
 ```
 
 ## List available profiles


### PR DESCRIPTION
The command `bombadil -p cool-sway` is missing the 'link' subcommand.