### PR TITLE
fix: correctly set direct within profiles

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,6 +438,12 @@ impl Bombadil {
                     let source = source.clone();
                     let target = target.clone();
                     let ignore = dot_override.ignore.clone();
+                    let direct;
+                    if dot_override.direct.is_some() {
+                        direct = dot_override.direct.unwrap()
+                    } else {
+                        direct = false;
+                    }
 
                     self.dots.insert(
                         key.to_string(),
@@ -446,7 +452,7 @@ impl Bombadil {
                             target,
                             ignore,
                             vars: Dot::default_vars(),
-                            direct: false,
+                            direct,
                         },
                     );
                 } else {
@@ -882,6 +888,25 @@ mod tests {
 
         // Assert
         assert_that!(content).is_equal_to(".class {color: #de1f1f}\n".to_string());
+
+        Ok(())
+    }
+
+    #[sealed_test(files = ["tests/dotfiles_with_profiles_direct"], before = setup("dotfiles_with_profiles_direct"))]
+    fn should_have_profiles_direct() -> Result<()> {
+        // Arrange
+        let mut bombadil = Bombadil::from_settings(NoGpg)?;
+        bombadil.enable_profiles(vec!["fancy"])?;
+
+        // Act
+        let css1 = bombadil.dots.get("css1").unwrap();
+        let css2 = bombadil.dots.get("css2").unwrap();
+        let css3 = bombadil.dots.get("css3").unwrap();
+
+        // Assert
+        assert_that!(css1.direct).is_equal_to(true);
+        assert_that!(css2.direct).is_equal_to(false);
+        assert_that!(css3.direct).is_equal_to(false);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,12 +438,11 @@ impl Bombadil {
                     let source = source.clone();
                     let target = target.clone();
                     let ignore = dot_override.ignore.clone();
-                    let direct;
-                    if dot_override.direct.is_some() {
-                        direct = dot_override.direct.unwrap()
+                    let direct = if dot_override.direct.is_some() {
+                        dot_override.direct.unwrap()
                     } else {
-                        direct = false;
-                    }
+                        false
+                    };
 
                     self.dots.insert(
                         key.to_string(),

--- a/tests/dotfiles_with_profiles_direct/bombadil.toml
+++ b/tests/dotfiles_with_profiles_direct/bombadil.toml
@@ -1,0 +1,7 @@
+
+dotfiles_dir = "dotfiles_with_profiles_direct"
+
+[profiles.fancy.dots]
+css1 = { source = "file.txt", target = ".config/file1.txt", direct = true }
+css2 = { source = "file.txt", target = ".config/file2.txt", direct = false }
+css3 = { source = "file.txt", target = ".config/file3.txt" }


### PR DESCRIPTION
Properly set the `direct` flag for dots defined in profiles.