### PR TITLE
fix: make `direct = true` dots idempotent and support directory targets

### DIFF
--- a/src/dots.rs
+++ b/src/dots.rs
@@ -90,10 +90,22 @@ impl Dot {
         match vars {
             Some(vars) if source.is_file() => self.render_file(source, target, vars),
             Some(vars) => self.render_directory(source, target, ignored, vars),
-            None => Ok(LinkResult::Direct {
-                source: source.clone(),
-                target: self.target()?,
-            }),
+            None => {
+                let resolved_target = self.target()?;
+                if let Ok(canonical_target) = resolved_target.canonicalize() {
+                    if let Ok(canonical_source) = source.canonicalize() {
+                        if canonical_target == canonical_source {
+                            return Ok(LinkResult::Unchanged {
+                                target: resolved_target,
+                            });
+                        }
+                    }
+                }
+                Ok(LinkResult::Direct {
+                    source: source.clone(),
+                    target: resolved_target,
+                })
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,9 @@ impl Bombadil {
                         LinkResult::Unchanged { .. } => {
                             // Ignoring those for now
                             // maybe we want to add them when implementing verbose mode
+                            if dot.direct {
+                                continue;
+                            }
                         }
                     }
                     dot.symlink(force)?;

--- a/src/paths/mod.rs
+++ b/src/paths/mod.rs
@@ -84,6 +84,14 @@ impl DotPaths for Dot {
         let path = shellexpand::tilde(path.as_ref());
         let target = Path::new(path.as_ref());
 
+        if let Ok(canonical_target) = target.canonicalize() {
+            if let Ok(canonical_source) = source.canonicalize() {
+                if canonical_target == canonical_source {
+                    return Ok(());
+                }
+            }
+        }
+
         if let Some(p) = target.parent() {
             fs::create_dir_all(p).ok();
         }
@@ -98,8 +106,7 @@ impl DotPaths for Dot {
             }
 
             println!("Backing up {} to {}", target.display(), backup.display());
-            fs::copy(target, backup)?;
-            fs::remove_file(target)?;
+            fs::rename(target, backup)?;
         }
 
         // Link
@@ -145,8 +152,7 @@ impl DotPaths for Dot {
             }
 
             println!("Backing up {} to {}", target.display(), backup.display());
-            fs::copy(target, backup)?;
-            fs::remove_file(target)?;
+            fs::rename(target, backup)?;
         }
 
         // Link


### PR DESCRIPTION
Fixes three issues with `direct = true` dots:

- re-runs fail with `AlreadyExists` because `symlink_direct` lacks the idempotency check that `symlink` has
- `-f` fails on directory targets because the backup uses `fs::copy` + `fs::remove_file` (file-only)
- `[Direct]` is printed on every run even when nothing changed.
